### PR TITLE
[RBT-281] Exception on invalid thumb encoding

### DIFF
--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -47,9 +47,7 @@ def load(input_data, key_is_name=False):
         start = exif_dict["1st"].get(ImageIFD.JPEGInterchangeFormat, None)
         length = exif_dict["1st"].get(ImageIFD.JPEGInterchangeFormatLength, None)
         if isinstance(start, int) and isinstance(length, int):
-            end = start + length
-            thumb = exifReader.tiftag[start:end]
-            exif_dict["thumbnail"] = thumb
+            exif_dict["thumbnail"] = exifReader.tiftag[start:start + length]
 
     if key_is_name:
         exif_dict = _get_key_name_dict(exif_dict)

--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -44,11 +44,11 @@ def load(input_data, key_is_name=False):
             exif_dict[name] = exifReader.get_ifd_dict(pointer, name)[0]
     if first_ifd_pointer:
         exif_dict["1st"] = exifReader.get_ifd_dict(first_ifd_pointer, "1st")[0]
-        if (ImageIFD.JPEGInterchangeFormat in exif_dict["1st"] and
-            ImageIFD.JPEGInterchangeFormatLength in exif_dict["1st"]):
-            end = (exif_dict["1st"][ImageIFD.JPEGInterchangeFormat] +
-                   exif_dict["1st"][ImageIFD.JPEGInterchangeFormatLength])
-            thumb = exifReader.tiftag[exif_dict["1st"][ImageIFD.JPEGInterchangeFormat]:end]
+        start = exif_dict["1st"].get(ImageIFD.JPEGInterchangeFormat, None)
+        length = exif_dict["1st"].get(ImageIFD.JPEGInterchangeFormatLength, None)
+        if isinstance(start, int) and isinstance(length, int):
+            end = start + length
+            thumb = exifReader.tiftag[start:end]
             exif_dict["thumbnail"] = thumb
 
     if key_is_name:

--- a/tests/s_test.py
+++ b/tests/s_test.py
@@ -662,6 +662,18 @@ class UTests(unittest.TestCase):
         ifd = er.get_ifd_dict(8, "0th", True)[0]
         self.assertEqual(ifd[ImageIFD.ProcessingSoftware], b"F")
 
+    def test_bad_thumb(self):
+        b1 = b"MM\x00\x2a\x00\x00\x00\x08"
+        zero = b"\x00\x01\x87\x69\x00\x04\x00\x00\x00\x01\x00\x00\x00\x1a\x00\x00\x00\x1a"
+        first = (
+            b"\x00\x02" +
+            b"\x02\x01\x00\x01\x00\x00\x00\x03\x01\x02\x03\x04" +
+            b"\x02\x02\x00\x01\x00\x00\x00\x03\x01\x02\x03\x04"
+        )
+        result = piexif._load.load(b1 + zero + first)
+        # should not crash
+        assert result
+
     def test_no_first_ifd(self):
         input = b'Exif\x00\x00II*\x00\x08\x00\x00\x00\00'
         for l in range(4, len(input)):


### PR DESCRIPTION
## Description

Issue: https://uploadcare.atlassian.net/browse/RBT-281

https://rollbar.com/Uploadcare/robots/items/1324/

Thumbnail is stored as field value, rather than as pointer.

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
